### PR TITLE
Turn off invalid bandit warning about jinja2

### DIFF
--- a/spoolman2slicer.py
+++ b/spoolman2slicer.py
@@ -82,7 +82,7 @@ parser.add_argument(
 args = parser.parse_args()
 
 loader = FileSystemLoader("templates-" + args.slicer)
-templates = Environment(loader=loader)
+templates = Environment(loader=loader) # nosec B701
 
 filament_id_to_filename = {}
 filament_id_to_content = {}


### PR DESCRIPTION
The warning is not relevant in this case as the created file isn't a html file being parsed and the data is the user's own data.